### PR TITLE
Fix 'open in ha' button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Quick Timer
 
-[![Add to Home Assistant](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=quick_timer)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=jozefnad&repository=homeassistant-quick_timer&category=Dashboard)
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/hacs/integration)
 [![GitHub Release](https://img.shields.io/github/release/jozefnad/homeassistant-quick_timer.svg)](https://github.com/jozefnad/homeassistant-quick_timer/releases)
 [![License](https://img.shields.io/github/license/jozefnad/homeassistant-quick_timer.svg)](LICENSE)


### PR DESCRIPTION
I noticed you're using the button on your readme for a native integration, but because this is a HACS integration you need this style of button so it opens properly. example: https://github.com/flixlix/power-flow-card-plus/blob/d13e135fd4ea0a5f0ede614ca95ba9217474986a/README.md?plain=1#L63